### PR TITLE
Try ell_1

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -241,9 +241,7 @@ fn pixel_f<const N: usize>(
 /// If the gradient is very small, then the value is scaled up based on the
 /// internal epsilon parameter
 pub fn normalize_g(g: Grad) -> Grad {
-    let norm = (g.dx.powi(2) + g.dy.powi(2) + g.dz.powi(2))
-        .sqrt()
-        .max(0.01);
+    let norm = (g.dx.abs() + g.dy.abs() + g.dz.abs()).max(0.01);
     Grad::new(g.v / norm, g.dx / norm, g.dy / norm, g.dz / norm)
 }
 
@@ -558,8 +556,7 @@ fn pseudo_interval_norm_split<const N: usize>(
             k += 1;
         }
     }
-    let r = (x.width().powi(2) + y.width().powi(2)).sqrt() / 2.0 / side as f32
-        * scale;
+    let r = x.width().max(y.width()) / 2.0 / side as f32 * scale;
     let (gs, choices) = pixel_gi(ops, scratch_g, xs, ys, scale, r, true);
     let vs = gs.map(|g| Interval::new(g.v - r, g.v + r));
     (vs, choices)


### PR DESCRIPTION
This changes the gradient normalization to ell_1, and also changes "radius" to mean the ell_infty radius. This seems to speed things up for me locally:
```
cargo run --release -- -i models/prospero.txt -o prospero.png --size 2048 --fancy --pseudo --normalize
```
goes from 87ms before this change to 66ms after.

But the change here isn't actually correct, and just after replying to you on mastodon I realized why: the whole approach assumes that the input tape is (ell_2)-Lipshitz, right? Well this version assumes that the input tape is ell_infty-Lipschitz, which is a stronger assumption. So to get a proper performance comparison, we'd need a different input tape to compare it with...

(Feel free to close this btw, this isn't a real PR. It was just the easiest way to share the diff...)